### PR TITLE
Implement colour mutations for procedure arguments.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,5 +44,6 @@ python_compressed.js
 /*compiler*.jar
 /local_blockly_compressed_vertical.js
 /chromedriver
+/out.txt
 # --flagfiles used on Windows
 /*.config

--- a/blocks_vertical/procedures.js
+++ b/blocks_vertical/procedures.js
@@ -29,7 +29,6 @@ goog.require('Blockly.Blocks');
 goog.require('Blockly.Colours');
 goog.require('Blockly.constants');
 goog.require('Blockly.ScratchBlocks.VerticalExtensions');
-// goog.require('Blockly.ColourMutation');
 
 // Serialization and deserialization.
 

--- a/blocks_vertical/procedures.js
+++ b/blocks_vertical/procedures.js
@@ -29,6 +29,7 @@ goog.require('Blockly.Blocks');
 goog.require('Blockly.Colours');
 goog.require('Blockly.constants');
 goog.require('Blockly.ScratchBlocks.VerticalExtensions');
+// goog.require('Blockly.ColourMutation');
 
 // Serialization and deserialization.
 
@@ -1091,7 +1092,9 @@ Blockly.Blocks['argument_reporter_boolean'] = {
       ],
       "extensions": ["colours_more", "output_boolean"]
     });
-  }
+  },
+  mutationToDom: function() { return Blockly.ColourMutation.mutationToDom.call(this, Blockly.Colours.more); },
+  domToMutation: Blockly.ColourMutation.domToMutation
 };
 
 Blockly.Blocks['argument_reporter_object'] = {
@@ -1106,7 +1109,9 @@ Blockly.Blocks['argument_reporter_object'] = {
       ],
       "extensions": ["colours_more", "output_object"]
     });
-  }
+  },
+  mutationToDom: function() { return Blockly.ColourMutation.mutationToDom.call(this, Blockly.Colours.more); },
+  domToMutation: Blockly.ColourMutation.domToMutation
 };
 
 Blockly.Blocks['argument_reporter_array'] = {
@@ -1121,7 +1126,9 @@ Blockly.Blocks['argument_reporter_array'] = {
       ],
       "extensions": ["colours_more", "output_array"]
     });
-  }
+  },
+  mutationToDom: function() { return Blockly.ColourMutation.mutationToDom.call(this, Blockly.Colours.more); },
+  domToMutation: Blockly.ColourMutation.domToMutation
 };
 
 Blockly.Blocks['argument_reporter_string_number'] = {
@@ -1136,7 +1143,9 @@ Blockly.Blocks['argument_reporter_string_number'] = {
       ],
       "extensions": ["colours_more", "output_number", "output_string"]
     });
-  }
+  },
+  mutationToDom: function() { return Blockly.ColourMutation.mutationToDom.call(this, Blockly.Colours.more); },
+  domToMutation: Blockly.ColourMutation.domToMutation
 };
 
 Blockly.Blocks['argument_editor_boolean'] = {

--- a/core/blockly.js
+++ b/core/blockly.js
@@ -30,6 +30,7 @@
  **/
 goog.provide('Blockly');
 
+goog.require('Blockly.ColourMutation');
 goog.require('Blockly.BlockSvg.render');
 goog.require('Blockly.DropDownDiv');
 goog.require('Blockly.Events');

--- a/core/colour_mutation.js
+++ b/core/colour_mutation.js
@@ -1,0 +1,60 @@
+/**
+ * @fileoverview Provides reusable colour dom mutation functions.
+ */
+
+'use strict';
+
+goog.provide('Blockly.ColourMutation');
+
+goog.require('goog.color');
+
+/** @const {object} Blockly.ColourMutation */
+var cm = {
+  PRIMARY: 'colourmutprimary',
+  SECONDARY: 'colourmutsecondary',
+  TERTIARY: 'colourmuttertiary',
+  QUATERNARY: 'colourmutquaternary'
+};
+Blockly.ColourMutation = cm;
+
+/**
+ * Generates a mutation node from the current block.
+ * @param {object} cols Default colours.
+ * @returns {Node} The mutation.
+ * @this Blockly.Block
+ */
+Blockly.ColourMutation.mutationToDom = function(cols) {
+  /** @const {Node} */
+  var mutation = document.createElement('mutation');
+  if (this.colour_ !== cols.primary && this.colour_)
+    mutation.setAttribute(cm.PRIMARY, this.colour_);
+  if (this.colourSecondary_ !== cols.secondary && this.colourSecondary_)
+    mutation.setAttribute(cm.SECONDARY, this.colourSecondary_);
+  if (this.colourTertiary_ !== cols.tertiary && this.colourTertiary_)
+    mutation.setAttribute(cm.TERTIARY, this.colourTertiary_);
+  if (this.colourQuaternary_ !== cols.quaternary && this.colourQuaternary_)
+    mutation.setAttribute(cm.QUATERNARY, this.colourQuaternary_);
+  return mutation;
+};
+
+/**
+ * Apply's the colours from the mutation node to the current block.
+ * @param {Node} node Them mutation object.
+ * @param {?boolean} skipApply Skip's running setColour, you can use this to prevent a rerender.
+ * @returns {string[]} The new colours.
+ * @this Blockly.Block
+ */
+Blockly.ColourMutation.domToMutation = function(node, skipApply) {
+  /** @const {string[]} */
+  var colours = [this.colour_, this.colourSecondary_, this.colourTertiary_, this.colourQuaternary_];
+  if (node.hasAttribute(cm.PRIMARY) && goog.color.isValidHexColor_(node.getAttribute(cm.PRIMARY)))
+    colours[0] = node.getAttribute(cm.PRIMARY);
+  if (node.hasAttribute(cm.SECONDARY) && goog.color.isValidHexColor_(node.getAttribute(cm.SECONDARY)))
+    colours[1] = node.getAttribute(cm.SECONDARY);
+  if (node.hasAttribute(cm.TERTIARY) && goog.color.isValidHexColor_(node.getAttribute(cm.TERTIARY)))
+    colours[2] = node.getAttribute(cm.TERTIARY);
+  if (node.hasAttribute(cm.QUATERNARY) && goog.color.isValidHexColor_(node.getAttribute(cm.QUATERNARY)))
+    colours[3] = node.getAttribute(cm.QUATERNARY);
+  if (!skipApply) this.setColour(...colours);
+  return colours;
+};


### PR DESCRIPTION
Allows for using mutation's to change the colour of argument reporters, the code is made to be reusable.
![image](https://github.com/user-attachments/assets/ac1c9ef4-f460-423e-a43c-d0a846ed8a71)

example extension:
```js
(function(Scratch) {
  if (!Scratch.extensions.unsandboxed) {
    throw new Error('Run this test unsandboxed.');
  }
  let boolXml = '<block type="argument_reporter_boolean"><field name="VALUE">bwah</field></block>';
  if (Scratch.gui) Scratch.gui.getBlockly().then(Blockly => {
    boolXml = boolXml.replace('</block>', `<mutation ${Blockly.ColourMutation.PRIMARY}="#ff0000"></mutation></block>`);
    vm.extensionManager.refreshBlocks();
  });
  class extension {
    getInfo() {
      return {
        id: '0znzwArgumentMutationColourTest',
        name: '_',
        blocks: [{
          blockType: Scratch.BlockType.XML,
          xml: boolXml,
        }],
      };
    }
  }
  Scratch.extensions.register(new extension());
})(Scratch);
```