### PR TITLE
fix default inputs not appearing

### DIFF
--- a/core/field_extendable.js
+++ b/core/field_extendable.js
@@ -31,7 +31,7 @@ Blockly.FieldExtendable = function(elements, defaultInputs, minInputs, maxInputs
   this.separator = separator;
   this.collapser = collapser;
 
-  this.inputs = undefined;
+  this.inputs = 0;
   this.defaultInputs = defaultInputs;
   this.addArgType('extendable');
 };


### PR DESCRIPTION
default inputs now appear

example block i made with defaultinputs set to 2:
| Before fix | After fix |
| -------- | ------- |
| ![image](https://github.com/user-attachments/assets/eaba8fee-c498-4962-a6c0-c2c8d7cf9c19) | ![image](https://github.com/user-attachments/assets/31032cbd-2cfe-45dd-b04b-c0f7239ff45d) |
