### PR TITLE
Berlin wall

### DIFF
--- a/blocks_vertical/data.js
+++ b/blocks_vertical/data.js
@@ -1133,7 +1133,6 @@ Blockly.Constants.Data.CUSTOM_CONTEXT_MENU_GET_LIST_MIXIN = {
                 variablesList[i].getId(), fieldName);
         options.push(option);
       }
-      options.push({separator: true});
       options.push({
         text: Blockly.Msg.REPLACE_LIST,
         enabled: true,

--- a/core/constants.js
+++ b/core/constants.js
@@ -352,6 +352,26 @@ Blockly.NEW_BROADCAST_MESSAGE_ID = 'NEW_BROADCAST_MESSAGE_ID';
 Blockly.NEW_VARIABLE_OPTION_ID = 'NEW_VARIABLE_OPTION_ID';
 
 /**
+ * String for use in the dropdown created in field_variable,
+ * specifically for broadcast messages.
+ * This string indicates that this option in the dropdown is 'Rename
+ * broadcast...' and if selected, should trigger the prompt to rename a
+ * broadcast message.
+ * @const {string}
+ */
+Blockly.RENAME_BROADCAST_ID = 'RENAME_BROADCAST_ID';
+
+/**
+ * String for use in the dropdown created in field_variable,
+ * specifically for broadcast messages.
+ * This string indicates that this option in the dropdown is 'Delete the "%1"
+ * broadcast' and if selected, should trigger the prompt to delete a broadcast
+ * message.
+ * @const {string}
+ */
+Blockly.DELETE_BROADCAST_ID = 'DELETE_BROADCAST_ID';
+
+/**
  * String representing the variable type of broadcast message blocks.
  * This string, for use in differentiating between types of variables,
  * indicates that the current variable is a broadcast message.

--- a/core/field_variable.js
+++ b/core/field_variable.js
@@ -357,7 +357,8 @@ Blockly.FieldVariable.dropdownCreate = function() {
     options.push([globalVariableModels[i].name, globalVariableModels[i].getId()]);
   }
   if (this.defaultType_ == Blockly.BROADCAST_MESSAGE_VARIABLE_TYPE) {
-    options.unshift(
+    options.push(Blockly.FieldDropdown.SEPARATOR);
+    options.push(
         [Blockly.Msg.NEW_BROADCAST_MESSAGE, Blockly.NEW_BROADCAST_MESSAGE_ID]);
     return options;
   }
@@ -374,7 +375,8 @@ Blockly.FieldVariable.dropdownCreate = function() {
     createNewText = Blockly.Msg.NEW_VARIABLE_OPTION;
     createNewType = '';
   }
-  options.unshift([createNewText, newVariableOptionId]);
+  options.push(Blockly.FieldDropdown.SEPARATOR);
+  options.push([createNewText, newVariableOptionId]);
 
   // When there is no selected variable yet, still offer creation action.
   if (!this.variable_) {

--- a/core/field_variable.js
+++ b/core/field_variable.js
@@ -328,12 +328,33 @@ Blockly.FieldVariable.dropdownCreate = function() {
       }
     }
   }
-  variableModelList.sort(Blockly.VariableModel.compareByName);
+  var localVariableModels = [];
+  var globalVariableModels = [];
+  for (var i = 0; i < variableModelList.length; i++) {
+    var variableForScope = variableModelList[i];
+    if (workspace && workspace.isFlyout && workspace.targetWorkspace) {
+      variableForScope = workspace.targetWorkspace.getVariableById(
+          variableModelList[i].getId()) || variableForScope;
+    }
+    if (variableForScope.isLocal) {
+      localVariableModels.push(variableModelList[i]);
+    } else {
+      globalVariableModels.push(variableModelList[i]);
+    }
+  }
+  localVariableModels.sort(Blockly.VariableModel.compareByName);
+  globalVariableModels.sort(Blockly.VariableModel.compareByName);
 
   var options = [];
-  for (var i = 0; i < variableModelList.length; i++) {
+  for (var i = 0; i < localVariableModels.length; i++) {
     // Set the uuid as the internal representation of the variable.
-    options[i] = [variableModelList[i].name, variableModelList[i].getId()];
+    options.push([localVariableModels[i].name, localVariableModels[i].getId()]);
+  }
+  if (localVariableModels.length && globalVariableModels.length) {
+    options.push(Blockly.FieldDropdown.SEPARATOR);
+  }
+  for (var i = 0; i < globalVariableModels.length; i++) {
+    options.push([globalVariableModels[i].name, globalVariableModels[i].getId()]);
   }
   if (this.defaultType_ == Blockly.BROADCAST_MESSAGE_VARIABLE_TYPE) {
     options.unshift(

--- a/core/field_variable.js
+++ b/core/field_variable.js
@@ -360,6 +360,16 @@ Blockly.FieldVariable.dropdownCreate = function() {
     options.push(Blockly.FieldDropdown.SEPARATOR);
     options.push(
         [Blockly.Msg.NEW_BROADCAST_MESSAGE, Blockly.NEW_BROADCAST_MESSAGE_ID]);
+    if (!this.variable_) {
+      return options;
+    }
+
+    options.push([Blockly.Msg.RENAME_BROADCAST, Blockly.RENAME_BROADCAST_ID]);
+    options.push(
+        [
+          Blockly.Msg.DELETE_BROADCAST.replace('%1', name),
+          Blockly.DELETE_BROADCAST_ID
+        ]);
     return options;
   }
 
@@ -415,7 +425,7 @@ Blockly.FieldVariable.dropdownCreate = function() {
 /**
  * Handle the selection of an item in the variable dropdown menu.
  * Special case the 'Rename variable...', 'Delete variable...',
- * and 'New message...' options.
+ * 'New message...', 'Rename broadcast...', and 'Delete broadcast...' options.
  * In the rename case, prompt the user for a new name.
  * @param {!goog.ui.Menu} menu The Menu component clicked.
  * @param {!goog.ui.MenuItem} menuItem The MenuItem selected within menu.
@@ -430,6 +440,14 @@ Blockly.FieldVariable.prototype.onItemSelected = function(menu, menuItem) {
       return;
     } else if (id == Blockly.DELETE_VARIABLE_ID) {
       // Delete variable.
+      workspace.deleteVariableById(this.variable_.getId());
+      return;
+    } else if (id == Blockly.RENAME_BROADCAST_ID) {
+      // Rename broadcast.
+      Blockly.Variables.renameVariable(workspace, this.variable_);
+      return;
+    } else if (id == Blockly.DELETE_BROADCAST_ID) {
+      // Delete broadcast.
       workspace.deleteVariableById(this.variable_.getId());
       return;
     } else if (id == Blockly.NEW_BROADCAST_MESSAGE_ID) {

--- a/core/variables.js
+++ b/core/variables.js
@@ -479,11 +479,9 @@ Blockly.Variables.renameVariable = function(workspace, variable,
   var promptMsg, modalTitle;
   var varType = variable.type;
   if (varType == Blockly.BROADCAST_MESSAGE_VARIABLE_TYPE) {
-    console.warn('Unexpected attempt to rename a broadcast message with ' +
-        'id: ' + variable.getId() + ' and name: ' + variable.name);
-    return;
-  }
-  if (varType == Blockly.TABLE_VARIABLE_TYPE) {
+    promptMsg = Blockly.Msg.RENAME_BROADCAST_TITLE;
+    modalTitle = Blockly.Msg.RENAME_BROADCAST_MODAL_TITLE;
+  } else if (varType == Blockly.TABLE_VARIABLE_TYPE) {
     promptMsg = Blockly.Msg.RENAME_TABLE_TITLE;
     modalTitle = Blockly.Msg.RENAME_TABLE_MODAL_TITLE;
   } else if (varType == Blockly.LIST_VARIABLE_TYPE) {

--- a/msg/messages.js
+++ b/msg/messages.js
@@ -497,3 +497,7 @@ Blockly.Msg.NEW_BROADCAST_MESSAGE = 'New message';
 Blockly.Msg.NEW_BROADCAST_MESSAGE_TITLE = 'New message name:';
 Blockly.Msg.BROADCAST_MODAL_TITLE = 'New Message';
 Blockly.Msg.DEFAULT_BROADCAST_MESSAGE_NAME = 'message1';
+Blockly.Msg.RENAME_BROADCAST = 'Rename broadcast';
+Blockly.Msg.RENAME_BROADCAST_TITLE = 'Rename all "%1" broadcasts to:';
+Blockly.Msg.RENAME_BROADCAST_MODAL_TITLE = 'Rename Broadcast';
+Blockly.Msg.DELETE_BROADCAST = 'Delete the "%1" broadcast';


### PR DESCRIPTION
- Add separator to all variable, list, table and broadcast menus to separate actions from options. (@CubesterYT)
- Put local variables at the top of the menu for quick access. (@CubesterYT)
- Place the New variable/list/table/broadcast option at the bottom. (@ddededodediamante)
- Add new "Rename broadcast" and "Delete broadcast" options for consistency with other menus. (@ddededodediamante)

<img width="398" height="245" alt="image" src="https://github.com/user-attachments/assets/e93a8640-f4e7-4e46-880e-0f070c4b9817" />
<img width="279" height="233" alt="image" src="https://github.com/user-attachments/assets/6bc1c482-dc91-424b-9cc9-8c8c4a3a6d54" />
<img width="299" height="238" alt="image" src="https://github.com/user-attachments/assets/7a59d462-776d-4537-ace9-f89c1878f72f" />
<img width="291" height="225" alt="image" src="https://github.com/user-attachments/assets/c4484d64-5106-4cd8-9a92-4390f1cb1efd" />
